### PR TITLE
Add SwiftUI product catalog example

### DIFF
--- a/ProductCatalogApp/Models/Product.swift
+++ b/ProductCatalogApp/Models/Product.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct Rating: Codable {
+    let rate: Double
+    let count: Int
+}
+
+struct Product: Codable, Identifiable, Hashable {
+    let id: Int
+    let title: String
+    let price: Double
+    let description: String
+    let category: String
+    let image: String
+    let rating: Rating
+}
+
+struct CartItem: Identifiable {
+    let id: Int
+    var product: Product
+    var quantity: Int
+}

--- a/ProductCatalogApp/ProductCatalogApp.swift
+++ b/ProductCatalogApp/ProductCatalogApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct ProductCatalogApp: App {
+    @StateObject private var viewModel = ProductViewModel()
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(viewModel)
+        }
+    }
+}

--- a/ProductCatalogApp/ViewModels/ProductViewModel.swift
+++ b/ProductCatalogApp/ViewModels/ProductViewModel.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Combine
+
+class ProductViewModel: ObservableObject {
+    @Published var products: [Product] = []
+    @Published var favorites: Set<Product> = []
+    @Published var cart: [CartItem] = []
+    @Published var selectedProduct: Product?
+
+    private var cancellables = Set<AnyCancellable>()
+    private let url = URL(string: "https://sugary-wool-penguin.glitch.me/products")!
+
+    init() {
+        fetchProducts()
+    }
+
+    func fetchProducts() {
+        URLSession.shared.dataTaskPublisher(for: url)
+            .map { $0.data }
+            .decode(type: [Product].self, decoder: JSONDecoder())
+            .replaceError(with: [])
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] items in
+                self?.products = items
+            }
+            .store(in: &cancellables)
+    }
+
+    func toggleFavorite(_ product: Product) {
+        if favorites.contains(product) {
+            favorites.remove(product)
+        } else {
+            favorites.insert(product)
+        }
+    }
+
+    func addToCart(_ product: Product) {
+        if let index = cart.firstIndex(where: { $0.id == product.id }) {
+            cart[index].quantity += 1
+        } else {
+            cart.append(CartItem(id: product.id, product: product, quantity: 1))
+        }
+    }
+
+    func removeFromCart(_ item: CartItem) {
+        cart.removeAll { $0.id == item.id }
+    }
+
+    func increaseQuantity(for item: CartItem) {
+        if let index = cart.firstIndex(where: { $0.id == item.id }) {
+            cart[index].quantity += 1
+        }
+    }
+
+    func decreaseQuantity(for item: CartItem) {
+        if let index = cart.firstIndex(where: { $0.id == item.id }) {
+            cart[index].quantity = max(1, cart[index].quantity - 1)
+        }
+    }
+
+    var totalPrice: Double {
+        cart.reduce(0) { $0 + ($1.product.price * Double($1.quantity)) }
+    }
+}

--- a/ProductCatalogApp/Views/CartView.swift
+++ b/ProductCatalogApp/Views/CartView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+struct CartView: View {
+    @EnvironmentObject var viewModel: ProductViewModel
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                List {
+                    ForEach(viewModel.cart) { item in
+                        HStack {
+                            AsyncImage(url: URL(string: item.product.image)) { phase in
+                                if let image = phase.image {
+                                    image.resizable().scaledToFit()
+                                } else {
+                                    Color.gray
+                                }
+                            }
+                            .frame(width: 50, height: 50)
+                            VStack(alignment: .leading) {
+                                Text(item.product.title)
+                                    .font(.headline)
+                                Text("$" + String(format: "%.2f", item.product.price))
+                                    .font(.subheadline)
+                            }
+                            Spacer()
+                            HStack {
+                                Button(action: {
+                                    viewModel.decreaseQuantity(for: item)
+                                }) {
+                                    Image(systemName: "minus.circle")
+                                }
+                                Text("\(item.quantity)")
+                                    .frame(width: 30)
+                                Button(action: {
+                                    viewModel.increaseQuantity(for: item)
+                                }) {
+                                    Image(systemName: "plus.circle")
+                                }
+                            }
+                            Button(action: {
+                                viewModel.removeFromCart(item)
+                            }) {
+                                Image(systemName: "trash")
+                                    .foregroundColor(.red)
+                            }
+                        }
+                    }
+                }
+                HStack {
+                    Text("Total: ")
+                    Spacer()
+                    Text("$" + String(format: "%.2f", viewModel.totalPrice))
+                        .bold()
+                }
+                .padding()
+                Button(action: {}) {
+                    Text("Pay Now")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                }
+                .padding([.horizontal, .bottom])
+            }
+            .navigationTitle("Cart")
+        }
+    }
+}

--- a/ProductCatalogApp/Views/ContentView.swift
+++ b/ProductCatalogApp/Views/ContentView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            HomeView()
+                .tabItem {
+                    Label("Home", systemImage: "house")
+                }
+            FavoritesView()
+                .tabItem {
+                    Label("Favorites", systemImage: "heart.fill")
+                }
+            CartView()
+                .tabItem {
+                    Label("Cart", systemImage: "cart")
+                }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+            .environmentObject(ProductViewModel())
+    }
+}

--- a/ProductCatalogApp/Views/FavoritesView.swift
+++ b/ProductCatalogApp/Views/FavoritesView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct FavoritesView: View {
+    @EnvironmentObject var viewModel: ProductViewModel
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(Array(viewModel.favorites), id: \._self) { product in
+                    HStack {
+                        AsyncImage(url: URL(string: product.image)) { phase in
+                            if let image = phase.image {
+                                image.resizable().scaledToFit()
+                            } else {
+                                Color.gray
+                            }
+                        }
+                        .frame(width: 50, height: 50)
+                        VStack(alignment: .leading) {
+                            Text(product.title)
+                            Text("$" + String(format: "%.2f", product.price))
+                                .font(.subheadline)
+                        }
+                        Spacer()
+                        Button(action: {
+                            viewModel.toggleFavorite(product)
+                        }) {
+                            Image(systemName: "heart.slash")
+                                .foregroundColor(.red)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Favorites")
+        }
+    }
+}

--- a/ProductCatalogApp/Views/HomeView.swift
+++ b/ProductCatalogApp/Views/HomeView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct HomeView: View {
+    @EnvironmentObject var viewModel: ProductViewModel
+    let columns = [GridItem(.flexible()), GridItem(.flexible())]
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(viewModel.products) { product in
+                        ProductCard(product: product)
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Products")
+        }
+    }
+}
+
+struct ProductCard: View {
+    @EnvironmentObject var viewModel: ProductViewModel
+    let product: Product
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            AsyncImage(url: URL(string: product.image)) { phase in
+                if let image = phase.image {
+                    image.resizable().scaledToFit()
+                } else if phase.error != nil {
+                    Color.red
+                } else {
+                    ProgressView()
+                }
+            }
+            .frame(height: 120)
+            Text(product.title)
+                .font(.headline)
+                .lineLimit(2)
+            Text("$" + String(format: "%.2f", product.price))
+                .font(.subheadline)
+            HStack {
+                Button(action: {
+                    viewModel.toggleFavorite(product)
+                }) {
+                    Image(systemName: viewModel.favorites.contains(product) ? "heart.fill" : "heart")
+                        .foregroundColor(.red)
+                }
+                Spacer()
+                Button(action: {
+                    viewModel.addToCart(product)
+                }) {
+                    Image(systemName: "cart.badge.plus")
+                }
+            }
+        }
+        .padding()
+        .background(Color(UIColor.secondarySystemBackground))
+        .cornerRadius(8)
+        .onTapGesture {
+            viewModel.selectedProduct = product
+        }
+        .sheet(item: $viewModel.selectedProduct) { prod in
+            ProductDetailView(product: prod)
+        }
+    }
+}

--- a/ProductCatalogApp/Views/ProductDetailView.swift
+++ b/ProductCatalogApp/Views/ProductDetailView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct ProductDetailView: View {
+    @EnvironmentObject var viewModel: ProductViewModel
+    let product: Product
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                AsyncImage(url: URL(string: product.image)) { phase in
+                    if let image = phase.image {
+                        image.resizable().scaledToFit()
+                    } else {
+                        ProgressView()
+                    }
+                }
+                Text(product.title)
+                    .font(.title)
+                Text("$" + String(format: "%.2f", product.price))
+                    .font(.title2)
+                Text(product.description)
+                HStack {
+                    Text("Category: \(product.category)")
+                    Spacer()
+                    Text("Rating: \(product.rating.rate, specifier: "%.1f") (
+                        product.rating.count)")
+                }
+                HStack {
+                    Button(action: {
+                        viewModel.toggleFavorite(product)
+                    }) {
+                        Image(systemName: viewModel.favorites.contains(product) ? "heart.fill" : "heart")
+                            .foregroundColor(.red)
+                    }
+                    Spacer()
+                    Button(action: {
+                        viewModel.addToCart(product)
+                    }) {
+                        Image(systemName: "cart.badge.plus")
+                    }
+                }
+                .padding(.top)
+            }
+            .padding()
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# App_IOS
+# ProductCatalog iOS App
+
+This project contains a basic SwiftUI application that fetches a list of products from an online service and displays them in a catalog. Users can mark items as favorites and add them to a cart. Both favorites and cart features are only stored in memory for demonstration purposes.
+
+## Requirements
+- Xcode 14 or later
+- iOS 15 or later
+
+## Running the App
+1. Open `ProductCatalogApp` folder in Xcode as a new project or add the files to an existing project.
+2. Build and run the app on the simulator or a physical device.
+
+The home view shows a grid of products. Tapping a product opens a detail sheet. Favorites and cart can be accessed from the bottom tab bar.


### PR DESCRIPTION
## Summary
- implement simple SwiftUI app under `ProductCatalogApp`
- model `Product` and view model to fetch data from API
- add views for home grid, favorites and cart
- document running instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848d08e1a44833293fecc9b64c0e320