### PR TITLE
Add product catalog app

### DIFF
--- a/PA3/PA3/AppState.swift
+++ b/PA3/PA3/AppState.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Combine
+
+class AppState: ObservableObject {
+    @Published var products: [Product] = []
+    @Published var detailSelection: Int?
+
+    @Published var favorites: Set<Int> = []
+    @Published var cart: [Int: Int] = [:] // productId -> quantity
+
+    func toggleFavorite(product: Product) {
+        if favorites.contains(product.id) {
+            favorites.remove(product.id)
+        } else {
+            favorites.insert(product.id)
+        }
+    }
+
+    func addToCart(product: Product) {
+        cart[product.id, default: 0] += 1
+    }
+
+    func removeFromCart(product: Product) {
+        cart[product.id] = nil
+    }
+
+    func updateQuantity(product: Product, quantity: Int) {
+        if quantity <= 0 {
+            cart[product.id] = nil
+        } else {
+            cart[product.id] = quantity
+        }
+    }
+
+    func totalAmount() -> Double {
+        var total = 0.0
+        for (id, qty) in cart {
+            if let product = products.first(where: { $0.id == id }) {
+                total += product.price * Double(qty)
+            }
+        }
+        return total
+    }
+}

--- a/PA3/PA3/CartView.swift
+++ b/PA3/PA3/CartView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct CartView: View {
+    @EnvironmentObject var state: AppState
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                List {
+                    ForEach(state.cart.keys.sorted(), id: .self) { id in
+                        if let product = state.products.first(where: { $0.id == id }) {
+                            CartRow(product: product)
+                        }
+                    }
+                }
+                HStack {
+                    Text("Total: $")
+                    Spacer()
+                    Text("$\(state.totalAmount(), specifier: "%.2f")")
+                }
+                .padding()
+                Button("Pagar ahora") {}
+                    .padding()
+                    .buttonStyle(.borderedProminent)
+            }
+            .navigationTitle("Cart")
+        }
+    }
+}
+
+struct CartRow: View {
+    @EnvironmentObject var state: AppState
+    let product: Product
+
+    var body: some View {
+        HStack {
+            AsyncImage(url: URL(string: product.image)) { phase in
+                switch phase {
+                case .empty:
+                    ProgressView()
+                case .success(let image):
+                    image.resizable().scaledToFit()
+                case .failure:
+                    Image(systemName: "photo")
+                @unknown default:
+                    EmptyView()
+                }
+            }
+            .frame(width: 60, height: 60)
+
+            VStack(alignment: .leading) {
+                Text(product.title)
+                    .font(.headline)
+                Text("$\(product.price, specifier: "%.2f")")
+                    .font(.subheadline)
+            }
+            Spacer()
+            Stepper(value: Binding(
+                get: { state.cart[product.id] ?? 1 },
+                set: { state.updateQuantity(product: product, quantity: $0) }
+            ), in: 1...99) {
+                Text("\(state.cart[product.id] ?? 1)")
+            }
+            Button(action: {
+                state.removeFromCart(product: product)
+            }) {
+                Image(systemName: "trash")
+            }
+        }
+    }
+}

--- a/PA3/PA3/ContentView.swift
+++ b/PA3/PA3/ContentView.swift
@@ -1,21 +1,24 @@
-//
-//  ContentView.swift
-//  PA3
-//
-//  Created by user269177 on 6/10/25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var state = AppState()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        TabView {
+            HomeView()
+                .tabItem {
+                    Label("Home", systemImage: "house")
+                }
+            FavoritesView()
+                .tabItem {
+                    Label("Favorites", systemImage: "heart")
+                }
+            CartView()
+                .tabItem {
+                    Label("Cart", systemImage: "cart")
+                }
         }
-        .padding()
+        .environmentObject(state)
     }
 }
 

--- a/PA3/PA3/FavoritesView.swift
+++ b/PA3/PA3/FavoritesView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct FavoritesView: View {
+    @EnvironmentObject var state: AppState
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(state.products.filter { state.favorites.contains($0.id) }) { product in
+                    HStack {
+                        AsyncImage(url: URL(string: product.image)) { phase in
+                            switch phase {
+                            case .empty:
+                                ProgressView()
+                            case .success(let image):
+                                image.resizable().scaledToFit()
+                            case .failure:
+                                Image(systemName: "photo")
+                            @unknown default:
+                                EmptyView()
+                            }
+                        }
+                        .frame(width: 60, height: 60)
+
+                        VStack(alignment: .leading) {
+                            Text(product.title)
+                                .font(.headline)
+                            Text("$\(product.price, specifier: "%.2f")")
+                                .font(.subheadline)
+                        }
+                        Spacer()
+                        Button(action: {
+                            state.toggleFavorite(product: product)
+                        }) {
+                            Image(systemName: "trash")
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .navigationTitle("Favorites")
+        }
+    }
+}

--- a/PA3/PA3/HomeView.swift
+++ b/PA3/PA3/HomeView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct HomeView: View {
+    @EnvironmentObject var state: AppState
+
+    var columns: [GridItem] = Array(repeating: .init(.flexible()), count: 2)
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(state.products) { product in
+                        ProductCardView(product: product)
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Home")
+        }
+        .task {
+            if state.products.isEmpty {
+                do {
+                    state.products = try await ProductService.shared.fetchProducts()
+                } catch {
+                    print(error)
+                }
+            }
+        }
+    }
+}
+
+struct ProductCardView: View {
+    @EnvironmentObject var state: AppState
+    let product: Product
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            AsyncImage(url: URL(string: product.image)) { phase in
+                switch phase {
+                case .empty:
+                    ProgressView()
+                case .success(let image):
+                    image.resizable().scaledToFit()
+                case .failure:
+                    Image(systemName: "photo")
+                @unknown default:
+                    EmptyView()
+                }
+            }
+            .frame(height: 100)
+
+            Text(product.title)
+                .font(.headline)
+                .lineLimit(2)
+
+            Text("$\(product.price, specifier: "%.2f")")
+                .font(.subheadline)
+
+            HStack {
+                Button(action: {
+                    state.toggleFavorite(product: product)
+                }) {
+                    Image(systemName: state.favorites.contains(product.id) ? "heart.fill" : "heart")
+                }
+                Button(action: {
+                    state.addToCart(product: product)
+                }) {
+                    Image(systemName: "cart")
+                }
+            }
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 8).stroke(Color.gray))
+        .onTapGesture {
+            state.detailSelection = product.id
+        }
+        .background(
+            NavigationLink(destination: ProductDetailView(product: product), tag: product.id, selection: $state.detailSelection) {
+                EmptyView()
+            }
+            .hidden()
+        )
+    }
+}

--- a/PA3/PA3/Product.swift
+++ b/PA3/PA3/Product.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct Product: Identifiable, Codable, Equatable {
+    let id: Int
+    let title: String
+    let price: Double
+    let description: String
+    let category: String
+    let image: String
+    let rating: Rating?
+
+    struct Rating: Codable, Equatable {
+        let rate: Double
+        let count: Int
+    }
+}

--- a/PA3/PA3/ProductDetailView.swift
+++ b/PA3/PA3/ProductDetailView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct ProductDetailView: View {
+    @EnvironmentObject var state: AppState
+    let product: Product
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                AsyncImage(url: URL(string: product.image)) { phase in
+                    switch phase {
+                    case .empty:
+                        ProgressView()
+                    case .success(let image):
+                        image.resizable().scaledToFit()
+                    case .failure:
+                        Image(systemName: "photo")
+                    @unknown default:
+                        EmptyView()
+                    }
+                }
+                .frame(height: 200)
+
+                Text(product.title)
+                    .font(.title)
+                Text("$\(product.price, specifier: "%.2f")")
+                    .font(.title3)
+                Text(product.description)
+                    .font(.body)
+                Text("Category: \(product.category)")
+                    .font(.footnote)
+                if let rating = product.rating {
+                    Text("Rating: \(rating.rate, specifier: "%.1f") (\(rating.count))")
+                        .font(.footnote)
+                }
+                HStack {
+                    Button(action: {
+                        state.toggleFavorite(product: product)
+                    }) {
+                        Image(systemName: state.favorites.contains(product.id) ? "heart.fill" : "heart")
+                    }
+                    Button(action: {
+                        state.addToCart(product: product)
+                    }) {
+                        Image(systemName: "cart")
+                    }
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Detail")
+    }
+}

--- a/PA3/PA3/ProductService.swift
+++ b/PA3/PA3/ProductService.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+class ProductService {
+    static let shared = ProductService()
+
+    func fetchProducts() async throws -> [Product] {
+        guard let url = URL(string: "https://sugary-wool-penguin.glitch.me/products") else {
+            return []
+        }
+        let (data, _) = try await URLSession.shared.data(from: url)
+        return try JSONDecoder().decode([Product].self, from: data)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # App_IOS
+
+Esta aplicación iOS muestra un catálogo de productos descargados desde `https://sugary-wool-penguin.glitch.me/products`.
+Cuenta con tres pestañas principales:
+
+- **Home**: grilla de productos. Desde aquí se pueden agregar a favoritos o al carrito y acceder al detalle de cada uno.
+- **Favorites**: lista con los productos marcados como favoritos.
+- **Cart**: lista de productos agregados al carrito con control de cantidades y cálculo de total.
+
+Las funciones de favoritos y carrito solo modifican el estado en memoria para fines de demostración.
+


### PR DESCRIPTION
## Summary
- implement a basic product model and data service
- add app state for favorites and cart
- create home, favorites, cart and product detail views
- host the views in a tab bar in `ContentView`
- update README with project details

## Testing
- `swiftc -swift-version 5 PA3/PA3/*.swift` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_6848d5e3718c833290ab4e844b037b0f